### PR TITLE
requests.py: removed assert scope["type"] == "http" in Request c…

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -200,7 +200,6 @@ class Request(HTTPConnection):
 
     def __init__(self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send):
         super().__init__(scope)
-        assert scope["type"] == "http"
         self._receive = receive
         self._send = send
         self._stream_consumed = False


### PR DESCRIPTION
…lass, it differs from parent class.

Parent class HTTPConnection `__init__` already handles the case when scope type is "websocket" but derived Request class does not, so it still raises an error.

<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
